### PR TITLE
update to use case-sensitive github.com/Seagate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Ignore the generated cxl-lib file
+/cxl-util

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ package main
 
 import (
     "fmt"
-    "github.com/seagate/cxl-lib/pkg/cxl"
+    "github.com/Seagate/cxl-lib/pkg/cxl"
 )
 
 func main() {

--- a/cmd/cxl-util/main.go
+++ b/cmd/cxl-util/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/seagate/cxl-lib/pkg/cxl"
+	"github.com/Seagate/cxl-lib/pkg/cxl"
 
 	"k8s.io/klog/v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seagate/cxl-lib
+module github.com/Seagate/cxl-lib
 
 go 1.20
 


### PR DESCRIPTION
- Update this library to use the case-sensitve github.com/Seagate path
- Ignore the cxl-util object file generated