### PR TITLE
Bugfix: remove extra `n` following `\n`

### DIFF
--- a/cmd/cxl-util/main.go
+++ b/cmd/cxl-util/main.go
@@ -158,7 +158,7 @@ func main() {
 
 	if settings.CEDT {
 		if cxl.ACPITables.CEDT == nil {
-			fmt.Printf("No CEDT table found on the system.\nn")
+			fmt.Printf("No CEDT table found on the system.\n")
 		} else {
 			fmt.Printf("\nCEDT table header:\n")
 			PrintTableToStdout(cxl.ACPITables.CEDT.Header, "   ", "   ")


### PR DESCRIPTION
I don't have a physical CXL device to test with anymore, however, I did notice there was an extra `n` being printed from `cxl-util --CEDT` when no CEDT table is found on the system. 