### PR TITLE
parse serial number from PCIE config space

### DIFF
--- a/cmd/cxl-util/main.go
+++ b/cmd/cxl-util/main.go
@@ -120,15 +120,15 @@ func main() {
 
 	devList := cxl.InitCxlDevList()
 	if settings.List {
-		prFmt := "%12s | %20s | %10s | %10s | %15s \n"
+		prFmt := "%12s | %20s | %10s | %10s | %15s | %18s \n"
 		fmt.Printf("Print the list of CXL devs. Total devices found: %d\n", len(devList))
-		fmt.Printf(prFmt, "BUS:DEV.FUN", "Vendor", "Device", "Rev", "Type")
+		fmt.Printf(prFmt, "BUS:DEV.FUN", "Vendor", "Device", "Rev", "Type", "SN")
 		for _, dev := range devList {
 			vendorName := dev.GetVendorInfo()
 			if len(vendorName) > 15 {
 				vendorName = vendorName[:15] + "..."
 			}
-			fmt.Printf(prFmt, dev.GetBdfString(), vendorName, dev.GetDeviceInfo(), dev.GetCxlRev(), dev.GetCxlType())
+			fmt.Printf(prFmt, dev.GetBdfString(), vendorName, dev.GetDeviceInfo(), dev.GetCxlRev(), dev.GetCxlType(), dev.GetSerialNumber())
 		}
 	}
 

--- a/pkg/cxl/cxl-struct.go
+++ b/pkg/cxl/cxl-struct.go
@@ -94,6 +94,14 @@ type PCIE_EXT_CAP_HDR struct {
 	DVSEC_hdr2      DVSEC_HDR2
 }
 
+type PCIE_DEVICE_SERIAL_NUMBER_CAP struct {
+	PCIE_ext_cap_ID bitfield_16b
+	Cap_Ver         bitfield_4b
+	Next_Cap_ofs    bitfield_12b
+	SN_low          uint32
+	SN_high         uint32
+}
+
 type PCIE_DVSEC_FOR_CXL struct {
 	PCIE_ext_cap_hdr     PCIE_EXT_CAP_HDR
 	CXL_cap              CXL_CAP


### PR DESCRIPTION
Parse serial number from PCIE config space extended capability
Store the value as hex string in cxl device object
